### PR TITLE
Worker and external worker service clean up

### DIFF
--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -19,7 +19,6 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "http",
  "integer-encoding",
  "moka",
  "once_cell",

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -23,11 +23,6 @@ edition = "2021"
 homepage = "https://beam.apache.org"
 license = "Apache-2.0"
 repository = "https://github.com/apache/beam"
-default-run = "main"
-
-[[bin]]
-name = "main"
-path = "src/main.rs"
 
 [dependencies]
 # Suggested by the compiler itself due to: https://github.com/rust-lang/rust/issues/91611

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -33,7 +33,6 @@ clap = { version = "4.0", features = ["derive"] }
 futures = "0.3.25"
 futures-core = "0.3"
 futures-util = "0.3"
-http = "0.2.8"
 integer-encoding = "3.0.4"
 moka = { version = "0.9.6", features = ["future"] }
 once_cell = "1.16.0"

--- a/sdks/rust/build.rs
+++ b/sdks/rust/build.rs
@@ -16,44 +16,28 @@
  * limitations under the License.
 */
 
-// TODO: compile protos in proto directory instead of the target directory for better
-// organization and to enable version control?
-fn main() {
-    let pipeline_root = "../../model/pipeline/src/main/proto";
-    let pipeline_dir = "../../model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1";
-
-    let fn_exec_root = "../../model/fn-execution/src/main/proto";
-    let fn_exec_dir =
-        "../../model/fn-execution/src/main/proto/org/apache/beam/model/fn_execution/v1";
-
-    let job_root = "../../model/job-management/src/main/proto";
-    let job_dir =
-        "../../model/job-management/src/main/proto/org/apache/beam/model/job_management/v1";
-
-    let interactive_root = "../../model/interactive/src/main/proto";
-    let interactive_dir =
-        "../../model/interactive/src/main/proto/org/apache/beam/model/interactive/v1";
-
-    tonic_build::configure()
-        .build_client(true)
-        .build_server(true)
-        .include_file("beam_api.rs")
-        .compile(
-            &[
-                format!("{}/{}", pipeline_dir, "beam_runner_api.proto"),
-                format!("{}/{}", pipeline_dir, "endpoints.proto"),
-                format!("{}/{}", pipeline_dir, "external_transforms.proto"),
-                format!("{}/{}", pipeline_dir, "metrics.proto"),
-                format!("{}/{}", pipeline_dir, "schema.proto"),
-                format!("{}/{}", pipeline_dir, "standard_window_fns.proto"),
-                format!("{}/{}", fn_exec_dir, "beam_fn_api.proto"),
-                format!("{}/{}", fn_exec_dir, "beam_provision_api.proto"),
-                format!("{}/{}", job_dir, "beam_artifact_api.proto"),
-                format!("{}/{}", job_dir, "beam_expansion_api.proto"),
-                format!("{}/{}", job_dir, "beam_job_api.proto"),
-                format!("{}/{}", interactive_dir, "beam_interactive_api.proto"),
-            ],
-            &[pipeline_root, fn_exec_root, job_root, interactive_root],
-        )
-        .unwrap_or_else(|e| panic!("Protobuf compile error: {:?}", e));
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure().compile(
+        &[
+            "org/apache/beam/model/fn_execution/v1/beam_fn_api.proto",
+            "org/apache/beam/model/fn_execution/v1/beam_provision_api.proto",
+            "org/apache/beam/model/interactive/v1/beam_interactive_api.proto",
+            "org/apache/beam/model/job_management/v1/beam_artifact_api.proto",
+            "org/apache/beam/model/job_management/v1/beam_expansion_api.proto",
+            "org/apache/beam/model/job_management/v1/beam_job_api.proto",
+            "org/apache/beam/model/pipeline/v1/beam_runner_api.proto",
+            "org/apache/beam/model/pipeline/v1/endpoints.proto",
+            "org/apache/beam/model/pipeline/v1/external_transforms.proto",
+            "org/apache/beam/model/pipeline/v1/metrics.proto",
+            "org/apache/beam/model/pipeline/v1/schema.proto",
+            "org/apache/beam/model/pipeline/v1/standard_window_fns.proto",
+        ],
+        &[
+            "../../model/fn-execution/src/main/proto",
+            "../../model/interactive/src/main/proto",
+            "../../model/job-management/src/main/proto",
+            "../../model/pipeline/src/main/proto",
+        ],
+    )?;
+    Ok(())
 }

--- a/sdks/rust/examples/wordcount.rs
+++ b/sdks/rust/examples/wordcount.rs
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+// TODO: Implement word count example
 fn main() {
     apache_beam::worker::worker_main::init();
     println!("Hello World!");

--- a/sdks/rust/src/internals/pipeline.rs
+++ b/sdks/rust/src/internals/pipeline.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use crate::coders::coders::CoderI;
-use crate::proto::beam_api::pipeline as proto_pipeline;
+use crate::proto::pipeline::v1 as pipeline_v1;
 
 use crate::internals::pvalue::{flatten_pvalue, PTransform, PValue};
 
@@ -61,7 +61,7 @@ impl PipelineContext {
 pub struct Pipeline {
     context: PipelineContext,
     default_environment: String,
-    proto: Arc<Mutex<proto_pipeline::Pipeline>>,
+    proto: Arc<Mutex<pipeline_v1::Pipeline>>,
     transform_stack: Arc<Mutex<Vec<String>>>,
     used_stage_names: Arc<Mutex<HashSet<String>>>,
 
@@ -74,8 +74,8 @@ pub struct Pipeline {
 
 impl<'a> Pipeline {
     pub fn new(component_prefix: String) -> Self {
-        let proto = proto_pipeline::Pipeline {
-            components: Some(proto_pipeline::Components {
+        let proto = pipeline_v1::Pipeline {
+            components: Some(pipeline_v1::Components {
                 transforms: HashMap::with_capacity(0),
                 pcollections: HashMap::with_capacity(0),
                 windowing_strategies: HashMap::with_capacity(0),
@@ -99,7 +99,7 @@ impl<'a> Pipeline {
         }
     }
 
-    pub fn get_proto(&self) -> Arc<std::sync::Mutex<proto_pipeline::Pipeline>> {
+    pub fn get_proto(&self) -> Arc<std::sync::Mutex<pipeline_v1::Pipeline>> {
         self.proto.clone()
     }
 
@@ -127,7 +127,7 @@ impl<'a> Pipeline {
     }
 
     // TODO: review need for separate function vs register_coder
-    pub fn register_coder_proto(&self, coder_proto: proto_pipeline::Coder) -> String {
+    pub fn register_coder_proto(&self, coder_proto: pipeline_v1::Coder) -> String {
         let mut pipeline_proto = self.proto.lock().unwrap();
 
         let proto_coders = &mut pipeline_proto.components.as_mut().unwrap().coders;
@@ -146,7 +146,7 @@ impl<'a> Pipeline {
         new_coder_id
     }
 
-    pub fn register_proto_transform(&self, transform: proto_pipeline::PTransform) {
+    pub fn register_proto_transform(&self, transform: pipeline_v1::PTransform) {
         let mut pipeline_proto = self.proto.lock().unwrap();
 
         pipeline_proto
@@ -161,14 +161,14 @@ impl<'a> Pipeline {
         &self,
         transform: &F,
         input: &PValue<In>,
-    ) -> (String, proto_pipeline::PTransform)
+    ) -> (String, pipeline_v1::PTransform)
     where
         In: Clone + Send,
         Out: Clone + Send,
         F: PTransform<In, Out> + Send,
     {
         let transform_id = self.context.create_unique_name("transform".to_string());
-        let mut parent: Option<&proto_pipeline::PTransform> = None;
+        let mut parent: Option<&pipeline_v1::PTransform> = None;
 
         let mut pipeline_proto = self.proto.lock().unwrap();
         let transform_stack = self.transform_stack.lock().unwrap();
@@ -217,7 +217,7 @@ impl<'a> Pipeline {
             inputs.insert(name.clone(), pvalue.get_id());
         }
 
-        let transform_proto = proto_pipeline::PTransform {
+        let transform_proto = pipeline_v1::PTransform {
             unique_name,
             spec: None,
             subtransforms: Vec::with_capacity(0),
@@ -269,7 +269,7 @@ impl<'a> Pipeline {
     pub fn post_apply_transform<In, Out, F>(
         &self,
         transform: F,
-        transform_proto: proto_pipeline::PTransform,
+        transform_proto: pipeline_v1::PTransform,
         result: PValue<Out>,
     ) -> PValue<Out>
     where
@@ -291,7 +291,7 @@ impl<'a> Pipeline {
         // TODO: remove pcoll_proto arg
         PValue::new(
             crate::internals::pvalue::PType::PCollection,
-            proto_pipeline::PCollection::default(),
+            pipeline_v1::PCollection::default(),
             pipeline,
             self.create_pcollection_id_internal(coder_id),
         )
@@ -299,7 +299,7 @@ impl<'a> Pipeline {
 
     pub fn create_pcollection_id_internal(&self, coder_id: String) -> String {
         let pcoll_id = self.context.create_unique_name("pc".to_string());
-        let mut pcoll_proto: proto_pipeline::PCollection = proto_pipeline::PCollection::default();
+        let mut pcoll_proto: pipeline_v1::PCollection = pipeline_v1::PCollection::default();
         pcoll_proto.unique_name = pcoll_id.clone();
         pcoll_proto.coder_id = coder_id;
 

--- a/sdks/rust/src/internals/pipeline.rs
+++ b/sdks/rust/src/internals/pipeline.rs
@@ -21,7 +21,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use crate::coders::coders::CoderI;
-use crate::proto::pipeline::v1 as pipeline_v1;
+use crate::proto::pipeline_v1;
 
 use crate::internals::pvalue::{flatten_pvalue, PTransform, PValue};
 

--- a/sdks/rust/src/internals/pvalue.rs
+++ b/sdks/rust/src/internals/pvalue.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use crate::coders::coders::CoderI;
 use crate::coders::required_coders::BytesCoder;
-use crate::proto::pipeline::v1 as pipeline_v1;
+use crate::proto::pipeline_v1;
 
 use crate::internals::pipeline::Pipeline;
 

--- a/sdks/rust/src/internals/pvalue.rs
+++ b/sdks/rust/src/internals/pvalue.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use crate::coders::coders::CoderI;
 use crate::coders::required_coders::BytesCoder;
-use crate::proto::beam_api::pipeline as proto_pipeline;
+use crate::proto::pipeline::v1 as pipeline_v1;
 
 use crate::internals::pipeline::Pipeline;
 
@@ -37,7 +37,7 @@ where
 {
     id: String,
     ptype: PType,
-    pcoll_proto: proto_pipeline::PCollection,
+    pcoll_proto: pipeline_v1::PCollection,
     pipeline: Arc<Pipeline>,
 
     phantom: PhantomData<T>,
@@ -49,7 +49,7 @@ where
 {
     pub fn new(
         ptype: PType,
-        pcoll_proto: proto_pipeline::PCollection,
+        pcoll_proto: pipeline_v1::PCollection,
         pipeline: Arc<Pipeline>,
         id: String,
     ) -> Self {
@@ -66,8 +66,8 @@ where
     pub fn new_root(pipeline: Arc<Pipeline>) -> Self {
         let pcoll_name = "root".to_string();
 
-        let proto_coder_id = pipeline.register_coder_proto(proto_pipeline::Coder {
-            spec: Some(proto_pipeline::FunctionSpec {
+        let proto_coder_id = pipeline.register_coder_proto(pipeline_v1::Coder {
+            spec: Some(pipeline_v1::FunctionSpec {
                 urn: String::from(crate::coders::urns::BYTES_CODER_URN),
                 payload: Vec::with_capacity(0),
             }),
@@ -76,15 +76,15 @@ where
 
         pipeline.register_coder::<BytesCoder, Vec<u8>>(Box::new(BytesCoder::new()));
 
-        let output_proto = proto_pipeline::PCollection {
+        let output_proto = pipeline_v1::PCollection {
             unique_name: pcoll_name.clone(),
             coder_id: proto_coder_id,
-            is_bounded: proto_pipeline::is_bounded::Enum::Bounded as i32,
+            is_bounded: pipeline_v1::is_bounded::Enum::Bounded as i32,
             windowing_strategy_id: "placeholder".to_string(),
             display_data: Vec::with_capacity(0),
         };
 
-        let impulse_proto = proto_pipeline::PTransform {
+        let impulse_proto = pipeline_v1::PTransform {
             unique_name: "root".to_string(),
             spec: None,
             subtransforms: Vec::with_capacity(0),
@@ -112,11 +112,11 @@ where
         self.pipeline.register_coder::<C, E>(coder)
     }
 
-    pub fn register_pipeline_coder_proto(&self, coder_proto: proto_pipeline::Coder) -> String {
+    pub fn register_pipeline_coder_proto(&self, coder_proto: pipeline_v1::Coder) -> String {
         self.pipeline.register_coder_proto(coder_proto)
     }
 
-    pub fn register_pipeline_proto_transform(&self, transform: proto_pipeline::PTransform) {
+    pub fn register_pipeline_proto_transform(&self, transform: pipeline_v1::PTransform) {
         self.pipeline.register_proto_transform(transform)
     }
 
@@ -201,7 +201,7 @@ where
         &self,
         input: &PValue<In>,
         pipeline: Arc<Pipeline>,
-        transform_proto: proto_pipeline::PTransform,
+        transform_proto: pipeline_v1::PTransform,
     ) -> PValue<Out>
     where
         Self: Sized,

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub mod coders;
 pub mod internals;
+#[allow(unused_imports)]
 pub mod proto;
 pub mod runners;
 pub mod transforms;

--- a/sdks/rust/src/proto.rs
+++ b/sdks/rust/src/proto.rs
@@ -41,3 +41,9 @@ pub mod pipeline {
         tonic::include_proto!("org.apache.beam.model.pipeline.v1");
     }
 }
+
+pub(crate) use expansion::v1 as expansion_v1;
+pub(crate) use fn_execution::v1 as fn_execution_v1;
+pub(crate) use interactive::v1 as interactive_v1;
+pub(crate) use job_management::v1 as job_management_v1;
+pub(crate) use pipeline::v1 as pipeline_v1;

--- a/sdks/rust/src/proto.rs
+++ b/sdks/rust/src/proto.rs
@@ -16,15 +16,28 @@
  * limitations under the License.
 */
 
-// TODO: move this to SDK root?
-
-#![allow(clippy::derive_partial_eq_without_eq, clippy::enum_variant_names)]
-pub mod beam_api {
-    tonic::include_proto!("beam_api");
-
-    pub use org::apache::beam::model::expansion::v1 as expansion;
-    pub use org::apache::beam::model::fn_execution::v1 as fn_execution;
-    pub use org::apache::beam::model::interactive::v1 as interactive;
-    pub use org::apache::beam::model::job_management::v1 as job_management;
-    pub use org::apache::beam::model::pipeline::v1 as pipeline;
+pub mod expansion {
+    pub mod v1 {
+        tonic::include_proto!("org.apache.beam.model.expansion.v1");
+    }
+}
+pub mod fn_execution {
+    pub mod v1 {
+        tonic::include_proto!("org.apache.beam.model.fn_execution.v1");
+    }
+}
+pub mod interactive {
+    pub mod v1 {
+        tonic::include_proto!("org.apache.beam.model.interactive.v1");
+    }
+}
+pub mod job_management {
+    pub mod v1 {
+        tonic::include_proto!("org.apache.beam.model.job_management.v1");
+    }
+}
+pub mod pipeline {
+    pub mod v1 {
+        tonic::include_proto!("org.apache.beam.model.pipeline.v1");
+    }
 }

--- a/sdks/rust/src/runners/direct_runner.rs
+++ b/sdks/rust/src/runners/direct_runner.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::proto::{fn_execution::v1::ProcessBundleDescriptor, pipeline::v1 as pipeline_v1};
+use crate::proto::{fn_execution_v1, pipeline_v1};
 use crate::worker::sdk_worker::BundleProcessor;
 
 use crate::runners::runner::RunnerI;
@@ -34,7 +34,7 @@ impl RunnerI for DirectRunner {
     }
 
     async fn run_pipeline(&self, pipeline: Arc<std::sync::Mutex<pipeline_v1::Pipeline>>) {
-        let descriptor: ProcessBundleDescriptor;
+        let descriptor: fn_execution_v1::ProcessBundleDescriptor;
         {
             let p = pipeline.lock().unwrap();
 
@@ -42,7 +42,7 @@ impl RunnerI for DirectRunner {
             // let proto = rewrite_side_inputs(pipeline, state_cache_ref);
 
             // TODO: review cloning
-            descriptor = ProcessBundleDescriptor {
+            descriptor = fn_execution_v1::ProcessBundleDescriptor {
                 id: "".to_string(),
                 transforms: p
                     .components

--- a/sdks/rust/src/runners/direct_runner.rs
+++ b/sdks/rust/src/runners/direct_runner.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::proto::beam_api::{fn_execution::ProcessBundleDescriptor, pipeline as proto_pipeline};
+use crate::proto::{fn_execution::v1::ProcessBundleDescriptor, pipeline::v1 as pipeline_v1};
 use crate::worker::sdk_worker::BundleProcessor;
 
 use crate::runners::runner::RunnerI;
@@ -33,7 +33,7 @@ impl RunnerI for DirectRunner {
         Self
     }
 
-    async fn run_pipeline(&self, pipeline: Arc<std::sync::Mutex<proto_pipeline::Pipeline>>) {
+    async fn run_pipeline(&self, pipeline: Arc<std::sync::Mutex<pipeline_v1::Pipeline>>) {
         let descriptor: ProcessBundleDescriptor;
         {
             let p = pipeline.lock().unwrap();

--- a/sdks/rust/src/runners/runner.rs
+++ b/sdks/rust/src/runners/runner.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 
 use crate::internals::pipeline::Pipeline;
 use crate::internals::pvalue::PValue;
-use crate::proto::pipeline::v1 as pipeline_v1;
+use crate::proto::pipeline_v1;
 
 pub type Task = Pin<Box<dyn Future<Output = ()> + Send>>;
 

--- a/sdks/rust/src/runners/runner.rs
+++ b/sdks/rust/src/runners/runner.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 
 use crate::internals::pipeline::Pipeline;
 use crate::internals::pvalue::PValue;
-use crate::proto::beam_api::pipeline as proto_pipeline;
+use crate::proto::pipeline::v1 as pipeline_v1;
 
 pub type Task = Pin<Box<dyn Future<Output = ()> + Send>>;
 
@@ -63,5 +63,5 @@ pub trait RunnerI {
         self.run_pipeline(p.get_proto()).await;
     }
 
-    async fn run_pipeline(&self, pipeline: Arc<std::sync::Mutex<proto_pipeline::Pipeline>>);
+    async fn run_pipeline(&self, pipeline: Arc<std::sync::Mutex<pipeline_v1::Pipeline>>);
 }

--- a/sdks/rust/src/tests/worker_test.rs
+++ b/sdks/rust/src/tests/worker_test.rs
@@ -23,10 +23,7 @@ mod tests {
     use serde_json;
 
     use crate::internals::urns;
-    use crate::proto::{
-        fn_execution::v1::ProcessBundleDescriptor,
-        pipeline::v1::{FunctionSpec, PTransform},
-    };
+    use crate::proto::{fn_execution_v1, pipeline_v1};
 
     use crate::{
         worker::sdk_worker::BundleProcessor,
@@ -38,10 +35,10 @@ mod tests {
         inputs: HashMap<String, String>,
         outputs: HashMap<String, String>,
         payload: Vec<u8>,
-    ) -> PTransform {
-        PTransform {
+    ) -> pipeline_v1::PTransform {
+        pipeline_v1::PTransform {
             unique_name: "".to_string(),
-            spec: Some(FunctionSpec {
+            spec: Some(pipeline_v1::FunctionSpec {
                 urn: urn.to_string(),
                 payload,
             }),
@@ -56,7 +53,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_operator_construction() {
-        let descriptor = ProcessBundleDescriptor {
+        let descriptor = fn_execution_v1::ProcessBundleDescriptor {
             id: "".to_string(),
             // Note the inverted order should still be resolved correctly
             transforms: HashMap::from([

--- a/sdks/rust/src/tests/worker_test.rs
+++ b/sdks/rust/src/tests/worker_test.rs
@@ -23,9 +23,9 @@ mod tests {
     use serde_json;
 
     use crate::internals::urns;
-    use crate::proto::beam_api::{
-        fn_execution::ProcessBundleDescriptor,
-        pipeline::{FunctionSpec, PTransform},
+    use crate::proto::{
+        fn_execution::v1::ProcessBundleDescriptor,
+        pipeline::v1::{FunctionSpec, PTransform},
     };
 
     use crate::{

--- a/sdks/rust/src/transforms/impulse.rs
+++ b/sdks/rust/src/transforms/impulse.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use crate::internals::pipeline::Pipeline;
 use crate::internals::pvalue::{PTransform, PValue};
-use crate::proto::pipeline::v1 as pipeline_v1;
+use crate::proto::pipeline_v1;
 
 pub struct Impulse {
     urn: &'static str,

--- a/sdks/rust/src/transforms/impulse.rs
+++ b/sdks/rust/src/transforms/impulse.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use crate::internals::pipeline::Pipeline;
 use crate::internals::pvalue::{PTransform, PValue};
-use crate::proto::beam_api::pipeline as proto_pipeline;
+use crate::proto::pipeline::v1 as pipeline_v1;
 
 pub struct Impulse {
     urn: &'static str,
@@ -43,9 +43,9 @@ impl PTransform<Never, Vec<u8>> for Impulse {
         &self,
         input: &PValue<Never>,
         pipeline: Arc<Pipeline>,
-        mut transform_proto: proto_pipeline::PTransform,
+        mut transform_proto: pipeline_v1::PTransform,
     ) -> PValue<Vec<u8>> {
-        let spec = proto_pipeline::FunctionSpec {
+        let spec = pipeline_v1::FunctionSpec {
             urn: self.urn.to_string(),
             payload: crate::internals::urns::IMPULSE_BUFFER.to_vec(),
         };

--- a/sdks/rust/src/worker/external_worker_service.rs
+++ b/sdks/rust/src/worker/external_worker_service.rs
@@ -27,7 +27,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 
-use crate::proto::beam_api::fn_execution::{
+use crate::proto::fn_execution::v1::{
     beam_fn_external_worker_pool_server, StartWorkerRequest, StartWorkerResponse,
     StopWorkerRequest, StopWorkerResponse,
 };

--- a/sdks/rust/src/worker/operators.rs
+++ b/sdks/rust/src/worker/operators.rs
@@ -25,8 +25,8 @@ use once_cell::sync::Lazy;
 use serde_json;
 
 use crate::internals::urns;
-use crate::proto::beam_api::fn_execution::{ProcessBundleDescriptor, RemoteGrpcPort};
-use crate::proto::beam_api::pipeline::PTransform;
+use crate::proto::fn_execution::v1::{ProcessBundleDescriptor, RemoteGrpcPort};
+use crate::proto::pipeline::v1::PTransform;
 
 use crate::worker::data::MultiplexingDataChannel;
 use crate::worker::sdk_worker::BundleProcessor;

--- a/sdks/rust/src/worker/operators.rs
+++ b/sdks/rust/src/worker/operators.rs
@@ -25,8 +25,7 @@ use once_cell::sync::Lazy;
 use serde_json;
 
 use crate::internals::urns;
-use crate::proto::fn_execution::v1::{ProcessBundleDescriptor, RemoteGrpcPort};
-use crate::proto::pipeline::v1::PTransform;
+use crate::proto::{fn_execution_v1, pipeline_v1};
 
 use crate::worker::data::MultiplexingDataChannel;
 use crate::worker::sdk_worker::BundleProcessor;
@@ -51,7 +50,7 @@ static OPERATORS_BY_URN: Lazy<Mutex<OperatorMap>> = Lazy::new(|| {
 pub trait OperatorI {
     fn new(
         transform_id: Arc<String>,
-        transform: Arc<PTransform>,
+        transform: Arc<pipeline_v1::PTransform>,
         context: Arc<OperatorContext>,
         operator_discriminant: OperatorDiscriminants,
     ) -> Self
@@ -81,7 +80,7 @@ pub enum Operator {
 impl OperatorI for Operator {
     fn new(
         transform_id: Arc<String>,
-        transform: Arc<PTransform>,
+        transform: Arc<pipeline_v1::PTransform>,
         context: Arc<OperatorContext>,
         operator_discriminant: OperatorDiscriminants,
     ) -> Self {
@@ -126,7 +125,7 @@ impl OperatorI for Operator {
 }
 
 pub fn create_operator(transform_id: &str, context: Arc<OperatorContext>) -> Operator {
-    let descriptor: &ProcessBundleDescriptor = context.descriptor.as_ref();
+    let descriptor: &fn_execution_v1::ProcessBundleDescriptor = context.descriptor.as_ref();
 
     let transform = descriptor
         .transforms
@@ -183,7 +182,7 @@ impl Receiver {
 }
 
 pub struct OperatorContext {
-    pub descriptor: Arc<ProcessBundleDescriptor>,
+    pub descriptor: Arc<fn_execution_v1::ProcessBundleDescriptor>,
     pub get_receiver: Box<dyn Fn(Arc<BundleProcessor>, String) -> Arc<Receiver> + Send + Sync>,
     // get_data_channel: fn(&str) -> MultiplexingDataChannel,
     // get_bundle_id: String,
@@ -214,7 +213,7 @@ pub enum WindowedValue {
 #[derive(Debug)]
 pub struct CreateOperator {
     transform_id: Arc<String>,
-    transform: Arc<PTransform>,
+    transform: Arc<pipeline_v1::PTransform>,
     context: Arc<OperatorContext>,
     operator_discriminant: OperatorDiscriminants,
 
@@ -225,7 +224,7 @@ pub struct CreateOperator {
 impl OperatorI for CreateOperator {
     fn new(
         transform_id: Arc<String>,
-        transform: Arc<PTransform>,
+        transform: Arc<pipeline_v1::PTransform>,
         context: Arc<OperatorContext>,
         operator_discriminant: OperatorDiscriminants,
     ) -> Self {
@@ -290,7 +289,7 @@ impl OperatorI for CreateOperator {
 #[derive(Debug)]
 pub struct RecordingOperator {
     transform_id: Arc<String>,
-    transform: Arc<PTransform>,
+    transform: Arc<pipeline_v1::PTransform>,
     context: Arc<OperatorContext>,
     operator_discriminant: OperatorDiscriminants,
 
@@ -300,7 +299,7 @@ pub struct RecordingOperator {
 impl OperatorI for RecordingOperator {
     fn new(
         transform_id: Arc<String>,
-        transform: Arc<PTransform>,
+        transform: Arc<pipeline_v1::PTransform>,
         context: Arc<OperatorContext>,
         operator_discriminant: OperatorDiscriminants,
     ) -> Self {

--- a/sdks/rust/src/worker/sdk_worker.rs
+++ b/sdks/rust/src/worker/sdk_worker.rs
@@ -28,15 +28,15 @@ use tonic::service::Interceptor;
 use tonic::transport::{Channel, Uri};
 use tonic::Status;
 
-use crate::proto::beam_api::fn_execution::{
+use crate::proto::fn_execution::v1::{
     beam_fn_control_client::BeamFnControlClient, FinalizeBundleRequest,
     GetProcessBundleDescriptorRequest, HarnessMonitoringInfosRequest, InstructionRequest,
     InstructionResponse, MonitoringInfosMetadataRequest, ProcessBundleDescriptor,
     ProcessBundleProgressRequest, ProcessBundleRequest, ProcessBundleResponse,
     ProcessBundleSplitRequest, ProcessBundleSplitResponse, RegisterRequest, RegisterResponse,
 };
-use crate::proto::beam_api::fn_execution::{instruction_request, instruction_response};
-use crate::proto::beam_api::pipeline::PTransform;
+use crate::proto::fn_execution::v1::{instruction_request, instruction_response};
+use crate::proto::pipeline::v1::PTransform;
 
 use crate::worker::operators::{create_operator, Operator, OperatorContext, OperatorI, Receiver};
 

--- a/sdks/rust/src/worker/sdk_worker.rs
+++ b/sdks/rust/src/worker/sdk_worker.rs
@@ -20,12 +20,11 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::sync::{Arc, Mutex, RwLock};
 
-use http::Uri;
 use tokio::sync::mpsc;
 use tonic::codegen::InterceptedService;
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::service::Interceptor;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, Uri};
 use tonic::Status;
 
 use crate::proto::beam_api::fn_execution::instruction_request;

--- a/sdks/rust/src/worker/sdk_worker.rs
+++ b/sdks/rust/src/worker/sdk_worker.rs
@@ -21,20 +21,21 @@ use std::error::Error;
 use std::sync::{Arc, Mutex, RwLock};
 
 use tokio::sync::mpsc;
+use tokio::sync::Mutex as TokioMutex;
 use tonic::codegen::InterceptedService;
 use tonic::metadata::{Ascii, MetadataValue};
 use tonic::service::Interceptor;
 use tonic::transport::{Channel, Uri};
 use tonic::Status;
 
-use crate::proto::beam_api::fn_execution::instruction_request;
 use crate::proto::beam_api::fn_execution::{
     beam_fn_control_client::BeamFnControlClient, FinalizeBundleRequest,
     GetProcessBundleDescriptorRequest, HarnessMonitoringInfosRequest, InstructionRequest,
     InstructionResponse, MonitoringInfosMetadataRequest, ProcessBundleDescriptor,
     ProcessBundleProgressRequest, ProcessBundleRequest, ProcessBundleResponse,
-    ProcessBundleSplitRequest, ProcessBundleSplitResponse, RegisterRequest,
+    ProcessBundleSplitRequest, ProcessBundleSplitResponse, RegisterRequest, RegisterResponse,
 };
+use crate::proto::beam_api::fn_execution::{instruction_request, instruction_response};
 use crate::proto::beam_api::pipeline::PTransform;
 
 use crate::worker::operators::{create_operator, Operator, OperatorContext, OperatorI, Receiver};
@@ -69,6 +70,9 @@ pub struct Worker {
     // Cheap and safe to clone
     control_client: BeamFnControlClient<InterceptedService<Channel, WorkerIdInterceptor>>,
     // Cheap and safe to clone
+    control_tx: mpsc::Sender<InstructionResponse>,
+    control_rx: Arc<TokioMutex<mpsc::Receiver<InstructionResponse>>>,
+    // Cheap and safe to clone
     process_bundle_descriptors:
         moka::future::Cache<BundleDescriptorId, Arc<ProcessBundleDescriptor>>,
     bundle_processors: HashMap<String, BundleProcessor>,
@@ -79,9 +83,8 @@ pub struct Worker {
 }
 
 impl Worker {
-    // TODO(sjvanrossum): Remove Arc and Mutex once the worker's state uses
     // concurrent data structures and/or finer grained locks.
-    pub async fn new(id: String, endpoints: WorkerEndpoints) -> Arc<Mutex<Worker>> {
+    pub async fn new(id: String, endpoints: WorkerEndpoints) -> Self {
         // TODO: parse URIs in the endpoint struct
         let channel = Channel::builder(endpoints.get_endpoint().parse::<Uri>().unwrap())
             .connect()
@@ -89,9 +92,12 @@ impl Worker {
             .expect("Failed to connect to control service");
         let client =
             BeamFnControlClient::with_interceptor(channel, WorkerIdInterceptor::new(id.clone()));
+        let (tx, rx) = mpsc::channel::<InstructionResponse>(100);
 
-        Arc::new(Mutex::new(Self {
+        Self {
             control_client: client,
+            control_tx: tx,
+            control_rx: Arc::new(TokioMutex::new(rx)),
             // TODO(sjvanrossum): Maybe define the eviction policy
             process_bundle_descriptors: moka::future::Cache::builder().build(),
             bundle_processors: HashMap::new(),
@@ -99,62 +105,61 @@ impl Worker {
             id,
             endpoints,
             options: HashMap::new(),
-        }))
+        }
     }
 
     pub async fn start(&mut self) -> Result<(), Box<dyn Error>> {
-        let (control_res_tx, mut control_res_rx) = mpsc::channel::<InstructionResponse>(100);
-
+        let rx = self.control_rx.clone();
         let outbound = async_stream::stream! {
-            while let Some(control_res) = control_res_rx.recv().await {
+            while let Some(control_res) = rx.lock().await.recv().await {
                 yield control_res
             }
         };
+
         let response = self.control_client.control(outbound).await?;
         let mut inbound = response.into_inner();
 
         while let Some(control_req) = inbound.message().await? {
             match control_req.request {
                 Some(instruction_request::Request::ProcessBundle(instr_req)) => {
-                    self.process_bundle(instr_req);
+                    self.process_bundle(control_req.instruction_id, instr_req);
                 }
                 Some(instruction_request::Request::ProcessBundleProgress(instr_req)) => {
-                    self.process_bundle_progress(instr_req);
+                    self.process_bundle_progress(control_req.instruction_id, instr_req);
                 }
                 Some(instruction_request::Request::ProcessBundleSplit(instr_req)) => {
-                    self.process_bundle_split(instr_req);
+                    self.process_bundle_split(control_req.instruction_id, instr_req);
                 }
                 Some(instruction_request::Request::FinalizeBundle(instr_req)) => {
-                    self.finalize_bundle(instr_req);
+                    self.finalize_bundle(control_req.instruction_id, instr_req);
                 }
                 Some(instruction_request::Request::MonitoringInfos(instr_req)) => {
-                    self.monitoring_infos(instr_req);
+                    self.monitoring_infos(control_req.instruction_id, instr_req);
                 }
                 Some(instruction_request::Request::HarnessMonitoringInfos(instr_req)) => {
-                    self.harness_monitoring_infos(instr_req);
+                    self.harness_monitoring_infos(control_req.instruction_id, instr_req);
                 }
                 Some(instruction_request::Request::Register(instr_req)) => {
-                    self.register(instr_req);
+                    self.register(control_req.instruction_id, instr_req);
                 }
                 _ => {
-                    control_res_tx
-                        .send(InstructionResponse {
-                            instruction_id: control_req.instruction_id.clone(),
-                            error: format!("Unexpected request: {:?}", control_req),
-                            response: None,
-                        })
-                        .await?;
+                    self.fail(
+                        control_req.instruction_id.clone(),
+                        format!("Unexpected request: {:?}", control_req),
+                        self.control_tx.clone(),
+                    )
+                    .await?;
                 }
             };
         }
         Ok(())
     }
 
-    pub fn stop(&mut self) {
-        todo!()
+    pub async fn stop(&self) {
+        self.control_rx.lock().await.close()
     }
 
-    fn process_bundle(&self, request: ProcessBundleRequest) -> () {
+    fn process_bundle(&self, instruction_id: InstructionId, request: ProcessBundleRequest) -> () {
         let mut client = self.control_client.clone();
         let descriptor_cache = self.process_bundle_descriptors.clone();
         tokio::spawn(async move {
@@ -175,28 +180,76 @@ impl Worker {
         });
     }
 
-    fn process_bundle_progress(&self, request: ProcessBundleProgressRequest) -> () {
+    fn process_bundle_progress(
+        &self,
+        instruction_id: InstructionId,
+        request: ProcessBundleProgressRequest,
+    ) -> () {
         // TODO(sjvanrossum): Flesh out after process_bundle is sufficiently implemented
     }
 
-    fn process_bundle_split(&self, request: ProcessBundleSplitRequest) -> () {
+    fn process_bundle_split(
+        &self,
+        instruction_id: InstructionId,
+        request: ProcessBundleSplitRequest,
+    ) -> () {
         // TODO(sjvanrossum): Flesh out after process_bundle is sufficiently implemented
     }
 
-    fn finalize_bundle(&self, request: FinalizeBundleRequest) -> () {
+    fn finalize_bundle(&self, instruction_id: InstructionId, request: FinalizeBundleRequest) -> () {
         // TODO(sjvanrossum): Flesh out after process_bundle is sufficiently implemented.
     }
 
-    fn monitoring_infos(&self, request: MonitoringInfosMetadataRequest) -> () {
+    fn monitoring_infos(
+        &self,
+        instruction_id: InstructionId,
+        request: MonitoringInfosMetadataRequest,
+    ) -> () {
         // TODO: Implement
     }
 
-    fn harness_monitoring_infos(&self, request: HarnessMonitoringInfosRequest) -> () {
+    fn harness_monitoring_infos(
+        &self,
+        instruction_id: InstructionId,
+        request: HarnessMonitoringInfosRequest,
+    ) -> () {
         // TODO: Implement
     }
 
-    fn register(&self, request: RegisterRequest) -> () {
-        // TODO: Implement or maybe respond with a failure since this is deprecated
+    fn register(&self, instruction_id: InstructionId, request: RegisterRequest) -> () {
+        let descriptor_cache = self.process_bundle_descriptors.clone();
+        let tx = self.control_tx.clone();
+        tokio::spawn(async move {
+            for descriptor in request.process_bundle_descriptor {
+                descriptor_cache
+                    .insert(descriptor.id.clone(), Arc::new(descriptor))
+                    .await;
+            }
+
+            tx.send(InstructionResponse {
+                instruction_id,
+                error: String::default(),
+                response: Some(instruction_response::Response::Register(
+                    RegisterResponse::default(),
+                )),
+            })
+            .await
+            .unwrap()
+        });
+    }
+
+    async fn fail(
+        &self,
+        instruction_id: InstructionId,
+        error: String,
+        tx: mpsc::Sender<InstructionResponse>,
+    ) -> Result<(), mpsc::error::SendError<InstructionResponse>> {
+        tx.send(InstructionResponse {
+            instruction_id: instruction_id,
+            error: error,
+            response: None,
+        })
+        .await
     }
 }
 

--- a/sdks/rust/src/worker/worker_main.rs
+++ b/sdks/rust/src/worker/worker_main.rs
@@ -45,6 +45,8 @@ pub fn init() {
 // TODO(sjvanrossum): Maybe make this an associated function, e.g. Worker::main?
 #[tokio::main]
 async fn worker_main(args: WorkerArgs) -> Result<(), Box<dyn Error>> {
-    let worker = Worker::new(args.id, WorkerEndpoints::new(Some(args.control_endpoint))).await;
-    Ok(())
+    Worker::new(args.id, WorkerEndpoints::new(Some(args.control_endpoint)))
+        .await
+        .start()
+        .await
 }


### PR DESCRIPTION
- Clean up:
  - Moved main into examples, removed a dependency on `http::Uri`, instead using `tonic::transport::Uri` (which is effectively just a `http::Uri` re-export, but could obviously change).
  - Removed refs in external worker service, replaced `std::sync::Mutex` with `tokio::sync::Mutex`, made sure to avoid creating, starting and re-inserting a worker if their worker id already exists and made sure to start the worker. I'm not sure if external Rust workers will be necessary ever, but we can look into that somewhere in the future.
- `Worker::stop` is async now and closes the control channel
- `Worker::new` now just returns `Self`, I checked that all synchronization is handled in `impl Worker`
- An implementation for `Register` instructions has been added (1 down and 6 to go, although register is deprecated)