### PR TITLE
feat: stop using `Any` (for statically typed Pipeline)

### DIFF
--- a/sdks/rust/src/coders/coders.rs
+++ b/sdks/rust/src/coders/coders.rs
@@ -82,23 +82,22 @@ pub enum CoderType {
 
 /// This is the base interface for coders, which are responsible in Apache Beam to encode and decode
 ///  elements of a PCollection.
-///
-/// # Type parameters
-///
-/// * `E` - The type of the elements to be encoded/decoded.
-pub trait CoderI<E> {
+pub trait CoderI {
+    /// The type of the elements to be encoded/decoded.
+    type E;
+
     fn get_coder_type(&self) -> &CoderTypeDiscriminants;
 
     /// Encode an element into a stream of bytes
     fn encode(
         &self,
-        element: E,
+        element: Self::E,
         writer: &mut dyn Write,
         context: &Context,
     ) -> Result<usize, io::Error>;
 
     /// Decode an element from an incoming stream of bytes
-    fn decode(&self, reader: &mut dyn Read, context: &Context) -> Result<E, io::Error>;
+    fn decode(&self, reader: &mut dyn Read, context: &Context) -> Result<Self::E, io::Error>;
 }
 
 /// The context for encoding a PCollection element.

--- a/sdks/rust/src/coders/coders.rs
+++ b/sdks/rust/src/coders/coders.rs
@@ -19,6 +19,7 @@
 pub mod coder_resolver;
 
 use std::collections::HashMap;
+use std::fmt;
 use std::io::{self, Read, Write};
 
 use crate::coders::urns::*;
@@ -84,15 +85,13 @@ pub enum CoderType {
 
 /// This is the base interface for coders, which are responsible in Apache Beam to encode and decode
 ///  elements of a PCollection.
-pub trait CoderI {
+pub trait CoderI: fmt::Debug + Default {
     /// The type of the elements to be encoded/decoded.
     type E;
 
     fn get_coder_urn() -> &'static str
     where
         Self: Sized;
-
-    fn get_coder_type(&self) -> &CoderTypeDiscriminants;
 
     /// Encode an element into a stream of bytes
     fn encode(

--- a/sdks/rust/src/coders/coders.rs
+++ b/sdks/rust/src/coders/coders.rs
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+pub mod coder_resolver;
+
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 

--- a/sdks/rust/src/coders/coders.rs
+++ b/sdks/rust/src/coders/coders.rs
@@ -88,6 +88,10 @@ pub trait CoderI {
     /// The type of the elements to be encoded/decoded.
     type E;
 
+    fn get_coder_urn() -> &'static str
+    where
+        Self: Sized;
+
     fn get_coder_type(&self) -> &CoderTypeDiscriminants;
 
     /// Encode an element into a stream of bytes

--- a/sdks/rust/src/coders/coders.rs
+++ b/sdks/rust/src/coders/coders.rs
@@ -82,19 +82,23 @@ pub enum CoderType {
 
 /// This is the base interface for coders, which are responsible in Apache Beam to encode and decode
 ///  elements of a PCollection.
-pub trait CoderI<T> {
+///
+/// # Type parameters
+///
+/// * `E` - The type of the elements to be encoded/decoded.
+pub trait CoderI<E> {
     fn get_coder_type(&self) -> &CoderTypeDiscriminants;
 
     /// Encode an element into a stream of bytes
     fn encode(
         &self,
-        element: T,
+        element: E,
         writer: &mut dyn Write,
         context: &Context,
     ) -> Result<usize, io::Error>;
 
     /// Decode an element from an incoming stream of bytes
-    fn decode(&self, reader: &mut dyn Read, context: &Context) -> Result<T, io::Error>;
+    fn decode(&self, reader: &mut dyn Read, context: &Context) -> Result<E, io::Error>;
 }
 
 /// The context for encoding a PCollection element.

--- a/sdks/rust/src/coders/coders.rs
+++ b/sdks/rust/src/coders/coders.rs
@@ -18,70 +18,8 @@
 
 pub mod coder_resolver;
 
-use std::collections::HashMap;
 use std::fmt;
 use std::io::{self, Read, Write};
-
-use crate::coders::urns::*;
-
-pub struct CoderRegistry {
-    internal_registry: HashMap<&'static str, CoderTypeDiscriminants>,
-}
-
-impl CoderRegistry {
-    pub fn new() -> Self {
-        let internal_registry: HashMap<&'static str, CoderTypeDiscriminants> = HashMap::from([
-            (BYTES_CODER_URN, CoderTypeDiscriminants::Bytes),
-            (
-                GENERAL_OBJECT_CODER_URN,
-                CoderTypeDiscriminants::GeneralObject,
-            ),
-            (KV_CODER_URN, CoderTypeDiscriminants::KV),
-            (ITERABLE_CODER_URN, CoderTypeDiscriminants::Iterable),
-            (STR_UTF8_CODER_URN, CoderTypeDiscriminants::StrUtf8),
-            (VARINT_CODER_URN, CoderTypeDiscriminants::VarIntCoder),
-        ]);
-
-        Self { internal_registry }
-    }
-
-    pub fn get_coder_type(&self, urn: &str) -> &CoderTypeDiscriminants {
-        let coder_type = self
-            .internal_registry
-            .get(urn)
-            .unwrap_or_else(|| panic!("No coder type registered for URN {urn}"));
-
-        coder_type
-    }
-
-    pub fn register(&mut self, urn: &'static str, coder_type: CoderTypeDiscriminants) {
-        self.internal_registry.insert(urn, coder_type);
-    }
-}
-
-impl Default for CoderRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Clone, EnumDiscriminants)]
-pub enum CoderType {
-    // ******* Required coders *******
-    Bytes,
-    Iterable,
-    KV,
-
-    // ******* Rust coders *******
-    GeneralObject,
-
-    // ******* Standard coders *******
-    StrUtf8,
-    VarIntCoder,
-}
-
-// TODO: create and use separate AnyCoder trait instead of Any
-// ...
 
 /// This is the base interface for coders, which are responsible in Apache Beam to encode and decode
 ///  elements of a PCollection.

--- a/sdks/rust/src/coders/coders/coder_resolver/mod.rs
+++ b/sdks/rust/src/coders/coders/coder_resolver/mod.rs
@@ -3,7 +3,7 @@ use std::{fmt, marker::PhantomData};
 use crate::{
     coders::{
         coders::CoderI,
-        required_coders::{BytesCoder, KVCoder, KV},
+        required_coders::{BytesCoder, Iterable, IterableCoder, KVCoder, KV},
     },
     elem_types::ElemType,
 };
@@ -47,4 +47,21 @@ where
 {
     type E = KV<K, V>;
     type C = KVCoder<Self::E>;
+}
+
+/// `Iterable` -> `IterableCoder`.
+#[derive(Debug)]
+pub struct IterableCoderResolverDefault<E>
+where
+    E: ElemType,
+{
+    phantom: PhantomData<E>,
+}
+
+impl<E> CoderResolver for IterableCoderResolverDefault<E>
+where
+    E: ElemType + fmt::Debug,
+{
+    type E = Iterable<E>;
+    type C = IterableCoder<Self::E>;
 }

--- a/sdks/rust/src/coders/coders/coder_resolver/mod.rs
+++ b/sdks/rust/src/coders/coders/coder_resolver/mod.rs
@@ -1,9 +1,12 @@
 use std::{fmt, marker::PhantomData};
 
+use integer_encoding::VarInt;
+
 use crate::{
     coders::{
         coders::CoderI,
         required_coders::{BytesCoder, Iterable, IterableCoder, KVCoder, KV},
+        standard_coders::{StrUtf8Coder, VarIntCoder},
     },
     elem_types::ElemType,
 };
@@ -64,4 +67,59 @@ where
 {
     type E = Iterable<E>;
     type C = IterableCoder<Self::E>;
+}
+
+/// `String` -> `StrUtf8Coder`.
+#[derive(Debug)]
+pub struct StrUtf8CoderResolverDefault;
+
+impl CoderResolver for StrUtf8CoderResolverDefault {
+    type E = String;
+    type C = StrUtf8Coder;
+}
+
+#[derive(Debug)]
+pub struct VarIntCoderResolverDefault<N: fmt::Debug + VarInt> {
+    phantom: PhantomData<N>,
+}
+
+impl CoderResolver for VarIntCoderResolverDefault<i8> {
+    type E = i8;
+    type C = VarIntCoder<i8>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<i16> {
+    type E = i16;
+    type C = VarIntCoder<i16>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<i32> {
+    type E = i32;
+    type C = VarIntCoder<i32>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<i64> {
+    type E = i64;
+    type C = VarIntCoder<i64>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<isize> {
+    type E = isize;
+    type C = VarIntCoder<isize>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<u8> {
+    type E = u8;
+    type C = VarIntCoder<u8>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<u16> {
+    type E = u16;
+    type C = VarIntCoder<u16>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<u32> {
+    type E = u32;
+    type C = VarIntCoder<u32>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<u64> {
+    type E = u64;
+    type C = VarIntCoder<u64>;
+}
+impl CoderResolver for VarIntCoderResolverDefault<usize> {
+    type E = usize;
+    type C = VarIntCoder<usize>;
 }

--- a/sdks/rust/src/coders/coders/coder_resolver/mod.rs
+++ b/sdks/rust/src/coders/coders/coder_resolver/mod.rs
@@ -1,0 +1,52 @@
+use std::marker::PhantomData;
+
+use crate::{
+    coders::{
+        coders::CoderI,
+        required_coders::{BytesCoder, KVCoder, KV},
+        urns::{BYTES_CODER_URN, KV_CODER_URN},
+    },
+    elem_types::ElemType,
+};
+
+/// Resolve a coder (implementing `CoderI) from a coder URN and an `ElemType`.
+pub trait CoderResolver {
+    type E: ElemType;
+
+    /// Resolve a coder from a coder URN.
+    ///
+    /// # Returns
+    ///
+    /// `Some(C)` if the coder was resolved, `None` otherwise.
+    fn resolve(&self, coder_urn: &str) -> Option<Box<dyn CoderI<E = Self::E>>>;
+}
+
+/// `Vec<u8>` -> `BytesCoder`.
+#[derive(Debug)]
+pub struct BytesCoderResolverDefault;
+
+impl CoderResolver for BytesCoderResolverDefault {
+    type E = Vec<u8>;
+
+    fn resolve(&self, coder_urn: &str) -> Option<Box<dyn CoderI<E = Self::E>>> {
+        (coder_urn == BYTES_CODER_URN).then_some(Box::<BytesCoder>::default())
+    }
+}
+
+/// `KV` -> `KVCoder`.
+#[derive(Debug)]
+pub struct KVCoderResolverDefault<K, V> {
+    phantom: PhantomData<KV<K, V>>,
+}
+
+impl<K, V> CoderResolver for KVCoderResolverDefault<K, V>
+where
+    K: Send + 'static,
+    V: Send + 'static,
+{
+    type E = KV<K, V>;
+
+    fn resolve(&self, coder_urn: &str) -> Option<Box<dyn CoderI<E = Self::E>>> {
+        (coder_urn == KV_CODER_URN).then_some(Box::<KVCoder<KV<K, V>>>::default())
+    }
+}

--- a/sdks/rust/src/coders/coders/coder_resolver/mod.rs
+++ b/sdks/rust/src/coders/coders/coder_resolver/mod.rs
@@ -10,6 +10,8 @@ use crate::{
 };
 
 /// Resolve a coder (implementing `CoderI) from a coder URN and an `ElemType`.
+///
+/// You may use original coders by implementing the `CoderResolver` trait.
 pub trait CoderResolver {
     type E: ElemType;
 

--- a/sdks/rust/src/coders/coders/coder_resolver/mod.rs
+++ b/sdks/rust/src/coders/coders/coder_resolver/mod.rs
@@ -19,6 +19,13 @@ pub trait CoderResolver {
     ///
     /// `Some(C)` if the coder was resolved, `None` otherwise.
     fn resolve(&self, coder_urn: &str) -> Option<Box<dyn CoderI<E = Self::E>>>;
+
+    fn _resolve_default<C: CoderI<E = Self::E> + Default + 'static>(
+        &self,
+        coder_urn: &str,
+    ) -> Option<Box<dyn CoderI<E = Self::E>>> {
+        (coder_urn == C::get_coder_urn()).then_some(Box::<C>::default())
+    }
 }
 
 /// `Vec<u8>` -> `BytesCoder`.
@@ -29,7 +36,7 @@ impl CoderResolver for BytesCoderResolverDefault {
     type E = Vec<u8>;
 
     fn resolve(&self, coder_urn: &str) -> Option<Box<dyn CoderI<E = Self::E>>> {
-        (coder_urn == BYTES_CODER_URN).then_some(Box::<BytesCoder>::default())
+        self._resolve_default::<BytesCoder>(coder_urn)
     }
 }
 
@@ -47,6 +54,6 @@ where
     type E = KV<K, V>;
 
     fn resolve(&self, coder_urn: &str) -> Option<Box<dyn CoderI<E = Self::E>>> {
-        (coder_urn == KV_CODER_URN).then_some(Box::<KVCoder<KV<K, V>>>::default())
+        self._resolve_default::<KVCoder<KV<K, V>>>(coder_urn)
     }
 }

--- a/sdks/rust/src/coders/coders/coder_resolver/mod.rs
+++ b/sdks/rust/src/coders/coders/coder_resolver/mod.rs
@@ -45,8 +45,8 @@ pub struct KVCoderResolverDefault<K, V> {
 
 impl<K, V> CoderResolver for KVCoderResolverDefault<K, V>
 where
-    K: fmt::Debug + Send + 'static,
-    V: fmt::Debug + Send + 'static,
+    K: Clone + fmt::Debug + Send + 'static,
+    V: Clone + fmt::Debug + Send + 'static,
 {
     type E = KV<K, V>;
     type C = KVCoder<Self::E>;

--- a/sdks/rust/src/coders/coders/coder_resolver/mod.rs
+++ b/sdks/rust/src/coders/coders/coder_resolver/mod.rs
@@ -4,7 +4,6 @@ use crate::{
     coders::{
         coders::CoderI,
         required_coders::{BytesCoder, KVCoder, KV},
-        urns::{BYTES_CODER_URN, KV_CODER_URN},
     },
     elem_types::ElemType,
 };

--- a/sdks/rust/src/coders/required_coders.rs
+++ b/sdks/rust/src/coders/required_coders.rs
@@ -152,8 +152,8 @@ pub struct KV<K, V> {
 
 impl<K, V> KV<K, V>
 where
-    K: Clone + fmt::Debug,
-    V: Clone + fmt::Debug,
+    K: Clone + fmt::Debug + Send,
+    V: Clone + fmt::Debug + Send,
 {
     pub fn new() -> Self {
         KV {
@@ -165,8 +165,8 @@ where
 
 impl<K, V> Default for KV<K, V>
 where
-    K: Clone + fmt::Debug,
-    V: Clone + fmt::Debug,
+    K: Clone + fmt::Debug + Send,
+    V: Clone + fmt::Debug + Send,
 {
     fn default() -> Self {
         Self::new()
@@ -204,6 +204,21 @@ impl<K, V> CoderI for KVCoder<KV<K, V>> {
     /// Decode the input byte stream into a `KV` element
     fn decode(&self, reader: &mut dyn Read, context: &Context) -> Result<KV<K, V>, io::Error> {
         todo!()
+    }
+}
+
+impl<K, V> Default for KVCoder<KV<K, V>>
+where
+    K: Send,
+    V: Send,
+{
+    fn default() -> Self {
+        Self {
+            coder_type: CoderTypeDiscriminants::KV,
+            urn: KV_CODER_URN,
+
+            phantom: PhantomData::default(),
+        }
     }
 }
 

--- a/sdks/rust/src/coders/required_coders.rs
+++ b/sdks/rust/src/coders/required_coders.rs
@@ -42,20 +42,22 @@ use crate::coders::urns::*;
 #[derive(Clone)]
 pub struct BytesCoder {
     coder_type: CoderTypeDiscriminants,
-    urn: &'static str,
 }
 
 impl BytesCoder {
     pub fn new() -> Self {
         BytesCoder {
             coder_type: CoderTypeDiscriminants::Bytes,
-            urn: BYTES_CODER_URN,
         }
     }
 }
 
 impl CoderI for BytesCoder {
     type E = Vec<u8>;
+
+    fn get_coder_urn() -> &'static str {
+        BYTES_CODER_URN
+    }
 
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
@@ -139,7 +141,7 @@ impl Default for BytesCoder {
 impl fmt::Debug for BytesCoder {
     fn fmt<'a>(&'a self, o: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         o.debug_struct("BytesCoder")
-            .field("urn", &self.urn)
+            .field("urn", &Self::get_coder_urn())
             .finish()
     }
 }
@@ -177,13 +179,16 @@ where
 #[derive(Clone)]
 pub struct KVCoder<KV> {
     coder_type: CoderTypeDiscriminants,
-    urn: &'static str,
 
     phantom: PhantomData<KV>,
 }
 
 impl<K, V> CoderI for KVCoder<KV<K, V>> {
     type E = KV<K, V>;
+
+    fn get_coder_urn() -> &'static str {
+        KV_CODER_URN
+    }
 
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
@@ -215,7 +220,6 @@ where
     fn default() -> Self {
         Self {
             coder_type: CoderTypeDiscriminants::KV,
-            urn: KV_CODER_URN,
 
             phantom: PhantomData::default(),
         }
@@ -226,7 +230,6 @@ where
 #[derive(Clone)]
 pub struct IterableCoder<T> {
     coder_type: CoderTypeDiscriminants,
-    urn: &'static str,
 
     phantom: PhantomData<T>,
 }
@@ -237,6 +240,10 @@ pub struct Iterable<T> {
 
 impl<T> CoderI for IterableCoder<T> {
     type E = Iterable<T>;
+
+    fn get_coder_urn() -> &'static str {
+        ITERABLE_CODER_URN
+    }
 
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type

--- a/sdks/rust/src/coders/required_coders.rs
+++ b/sdks/rust/src/coders/required_coders.rs
@@ -54,7 +54,9 @@ impl BytesCoder {
     }
 }
 
-impl CoderI<Vec<u8>> for BytesCoder {
+impl CoderI for BytesCoder {
+    type E = Vec<u8>;
+
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
     }
@@ -180,7 +182,9 @@ pub struct KVCoder<KV> {
     phantom: PhantomData<KV>,
 }
 
-impl<K, V> CoderI<KV<K, V>> for KVCoder<KV<K, V>> {
+impl<K, V> CoderI for KVCoder<KV<K, V>> {
+    type E = KV<K, V>;
+
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
     }
@@ -216,7 +220,9 @@ pub struct Iterable<T> {
     phantom: PhantomData<T>,
 }
 
-impl<T> CoderI<Iterable<T>> for IterableCoder<T> {
+impl<T> CoderI for IterableCoder<T> {
+    type E = Iterable<T>;
+
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
     }

--- a/sdks/rust/src/coders/required_coders.rs
+++ b/sdks/rust/src/coders/required_coders.rs
@@ -212,7 +212,7 @@ where
     phantom: PhantomData<E>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Iterable<E>
 where
     E: ElemType,

--- a/sdks/rust/src/coders/required_coders.rs
+++ b/sdks/rust/src/coders/required_coders.rs
@@ -37,6 +37,7 @@ use integer_encoding::{VarIntReader, VarIntWriter};
 
 use crate::coders::coders::{CoderI, Context};
 use crate::coders::urns::*;
+use crate::elem_types::ElemType;
 
 /// Coder for byte-array data types
 #[derive(Clone, Default)]
@@ -204,20 +205,26 @@ where
 
 /// A coder for a 'list' or a series of elements of the same type
 #[derive(Clone, Debug)]
-pub struct IterableCoder<T> {
-    phantom: PhantomData<T>,
+pub struct IterableCoder<E>
+where
+    E: ElemType,
+{
+    phantom: PhantomData<E>,
 }
 
 #[derive(Debug)]
-pub struct Iterable<T> {
-    phantom: PhantomData<T>,
+pub struct Iterable<E>
+where
+    E: ElemType,
+{
+    phantom: PhantomData<E>,
 }
 
-impl<T> CoderI for IterableCoder<T>
+impl<ItE> CoderI for IterableCoder<ItE>
 where
-    T: fmt::Debug,
+    ItE: ElemType + fmt::Debug,
 {
-    type E = Iterable<T>;
+    type E = ItE;
 
     fn get_coder_urn() -> &'static str {
         ITERABLE_CODER_URN
@@ -233,7 +240,7 @@ where
     /// Then, each element is encoded individually in `Context::NeedsDelimiters`.
     fn encode(
         &self,
-        element: Iterable<T>,
+        element: ItE,
         writer: &mut dyn Write,
         context: &Context,
     ) -> Result<usize, io::Error> {
@@ -241,12 +248,15 @@ where
     }
 
     /// Decode the input byte stream into a `Iterable` element
-    fn decode(&self, reader: &mut dyn Read, context: &Context) -> Result<Iterable<T>, io::Error> {
+    fn decode(&self, reader: &mut dyn Read, context: &Context) -> Result<ItE, io::Error> {
         todo!()
     }
 }
 
-impl<T> Default for IterableCoder<T> {
+impl<E> Default for IterableCoder<E>
+where
+    E: ElemType,
+{
     fn default() -> Self {
         Self {
             phantom: PhantomData::default(),

--- a/sdks/rust/src/coders/rust_coders.rs
+++ b/sdks/rust/src/coders/rust_coders.rs
@@ -42,7 +42,9 @@ impl<T> GeneralObjectCoder<T> {
     }
 }
 
-impl CoderI<String> for GeneralObjectCoder<String> {
+impl CoderI for GeneralObjectCoder<String> {
+    type E = String;
+
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
     }

--- a/sdks/rust/src/coders/rust_coders.rs
+++ b/sdks/rust/src/coders/rust_coders.rs
@@ -26,7 +26,6 @@ use crate::coders::urns::*;
 #[derive(Eq, PartialEq)]
 pub struct GeneralObjectCoder<T> {
     coder_type: CoderTypeDiscriminants,
-    urn: &'static str,
 
     phantom: PhantomData<T>,
 }
@@ -35,7 +34,6 @@ impl<T> GeneralObjectCoder<T> {
     pub fn new() -> Self {
         Self {
             coder_type: CoderTypeDiscriminants::GeneralObject,
-            urn: GENERAL_OBJECT_CODER_URN,
 
             phantom: PhantomData::default(),
         }
@@ -44,6 +42,10 @@ impl<T> GeneralObjectCoder<T> {
 
 impl CoderI for GeneralObjectCoder<String> {
     type E = String;
+
+    fn get_coder_urn() -> &'static str {
+        GENERAL_OBJECT_CODER_URN
+    }
 
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
@@ -86,7 +88,7 @@ impl<T> Default for GeneralObjectCoder<T> {
 impl<T> fmt::Debug for GeneralObjectCoder<T> {
     fn fmt<'a>(&'a self, o: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         o.debug_struct("GeneralObjectCoder")
-            .field("urn", &self.urn)
+            .field("urn", &GENERAL_OBJECT_CODER_URN)
             .finish()
     }
 }

--- a/sdks/rust/src/coders/rust_coders.rs
+++ b/sdks/rust/src/coders/rust_coders.rs
@@ -19,25 +19,13 @@
 use std::fmt;
 use std::marker::PhantomData;
 
-use crate::coders::coders::{CoderI, CoderTypeDiscriminants};
+use crate::coders::coders::CoderI;
 use crate::coders::standard_coders::*;
 use crate::coders::urns::*;
 
 #[derive(Eq, PartialEq)]
 pub struct GeneralObjectCoder<T> {
-    coder_type: CoderTypeDiscriminants,
-
     phantom: PhantomData<T>,
-}
-
-impl<T> GeneralObjectCoder<T> {
-    pub fn new() -> Self {
-        Self {
-            coder_type: CoderTypeDiscriminants::GeneralObject,
-
-            phantom: PhantomData::default(),
-        }
-    }
 }
 
 impl CoderI for GeneralObjectCoder<String> {
@@ -45,10 +33,6 @@ impl CoderI for GeneralObjectCoder<String> {
 
     fn get_coder_urn() -> &'static str {
         GENERAL_OBJECT_CODER_URN
-    }
-
-    fn get_coder_type(&self) -> &CoderTypeDiscriminants {
-        &self.coder_type
     }
 
     fn encode(
@@ -60,7 +44,7 @@ impl CoderI for GeneralObjectCoder<String> {
         let marker = "S".as_bytes();
         writer.write_all(marker).unwrap();
 
-        StrUtf8Coder::new().encode(element, writer, context)
+        StrUtf8Coder::default().encode(element, writer, context)
     }
 
     fn decode(
@@ -75,13 +59,15 @@ impl CoderI for GeneralObjectCoder<String> {
             todo!()
         }
 
-        StrUtf8Coder::new().decode(reader, context)
+        StrUtf8Coder::default().decode(reader, context)
     }
 }
 
 impl<T> Default for GeneralObjectCoder<T> {
     fn default() -> Self {
-        Self::new()
+        Self {
+            phantom: PhantomData::default(),
+        }
     }
 }
 

--- a/sdks/rust/src/coders/standard_coders.rs
+++ b/sdks/rust/src/coders/standard_coders.rs
@@ -39,14 +39,12 @@ use crate::coders::urns::*;
 #[derive(Clone)]
 pub struct StrUtf8Coder {
     coder_type: CoderTypeDiscriminants,
-    urn: &'static str,
 }
 
 impl StrUtf8Coder {
     pub fn new() -> Self {
         Self {
             coder_type: CoderTypeDiscriminants::StrUtf8,
-            urn: STR_UTF8_CODER_URN,
         }
     }
 }
@@ -54,6 +52,10 @@ impl StrUtf8Coder {
 // TODO: accept string references as well?
 impl CoderI for StrUtf8Coder {
     type E = String;
+
+    fn get_coder_urn() -> &'static str {
+        STR_UTF8_CODER_URN
+    }
 
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
@@ -96,7 +98,7 @@ impl Default for StrUtf8Coder {
 impl fmt::Debug for StrUtf8Coder {
     fn fmt<'a>(&'a self, o: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         o.debug_struct("StrUtf8Coder")
-            .field("urn", &self.urn)
+            .field("urn", &Self::get_coder_urn())
             .finish()
     }
 }
@@ -104,7 +106,6 @@ impl fmt::Debug for StrUtf8Coder {
 #[derive(Clone)]
 pub struct VarIntCoder<N: fmt::Debug + VarInt> {
     coder_type: CoderTypeDiscriminants,
-    urn: &'static str,
     _var_int_type: std::marker::PhantomData<N>,
 }
 
@@ -112,7 +113,6 @@ impl<N: fmt::Debug + VarInt> VarIntCoder<N> {
     pub fn new() -> Self {
         Self {
             coder_type: CoderTypeDiscriminants::VarIntCoder,
-            urn: VARINT_CODER_URN,
             _var_int_type: std::marker::PhantomData,
         }
     }
@@ -125,6 +125,10 @@ where
     N: fmt::Debug + VarInt,
 {
     type E = N;
+
+    fn get_coder_urn() -> &'static str {
+        VARINT_CODER_URN
+    }
 
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
@@ -154,7 +158,7 @@ impl<N: fmt::Debug + VarInt> Default for VarIntCoder<N> {
 impl<N: fmt::Debug + VarInt> fmt::Debug for VarIntCoder<N> {
     fn fmt<'a>(&'a self, o: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         o.debug_struct("VarIntCoder")
-            .field("urn", &self.urn)
+            .field("urn", &Self::get_coder_urn())
             .finish()
     }
 }

--- a/sdks/rust/src/coders/standard_coders.rs
+++ b/sdks/rust/src/coders/standard_coders.rs
@@ -52,7 +52,9 @@ impl StrUtf8Coder {
 }
 
 // TODO: accept string references as well?
-impl CoderI<String> for StrUtf8Coder {
+impl CoderI for StrUtf8Coder {
+    type E = String;
+
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
     }
@@ -100,26 +102,30 @@ impl fmt::Debug for StrUtf8Coder {
 }
 
 #[derive(Clone)]
-pub struct VarIntCoder {
+pub struct VarIntCoder<N: fmt::Debug + VarInt> {
     coder_type: CoderTypeDiscriminants,
     urn: &'static str,
+    _var_int_type: std::marker::PhantomData<N>,
 }
 
-impl VarIntCoder {
+impl<N: fmt::Debug + VarInt> VarIntCoder<N> {
     pub fn new() -> Self {
         Self {
             coder_type: CoderTypeDiscriminants::VarIntCoder,
             urn: VARINT_CODER_URN,
+            _var_int_type: std::marker::PhantomData,
         }
     }
 }
 
 // TODO: passes tests for -1 if it gets casted to u64 and encoded as such.
 // Revisit this later
-impl<N> CoderI<N> for VarIntCoder
+impl<N> CoderI for VarIntCoder<N>
 where
     N: fmt::Debug + VarInt,
 {
+    type E = N;
+
     fn get_coder_type(&self) -> &CoderTypeDiscriminants {
         &self.coder_type
     }
@@ -139,13 +145,13 @@ where
     }
 }
 
-impl Default for VarIntCoder {
+impl<N: fmt::Debug + VarInt> Default for VarIntCoder<N> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl fmt::Debug for VarIntCoder {
+impl<N: fmt::Debug + VarInt> fmt::Debug for VarIntCoder<N> {
     fn fmt<'a>(&'a self, o: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         o.debug_struct("VarIntCoder")
             .field("urn", &self.urn)

--- a/sdks/rust/src/coders/standard_coders.rs
+++ b/sdks/rust/src/coders/standard_coders.rs
@@ -32,22 +32,12 @@ use std::io::{self, ErrorKind, Read, Write};
 
 use integer_encoding::{VarInt, VarIntReader, VarIntWriter};
 
-use crate::coders::coders::{CoderI, CoderTypeDiscriminants, Context};
+use crate::coders::coders::{CoderI, Context};
 use crate::coders::required_coders::BytesCoder;
 use crate::coders::urns::*;
 
-#[derive(Clone)]
-pub struct StrUtf8Coder {
-    coder_type: CoderTypeDiscriminants,
-}
-
-impl StrUtf8Coder {
-    pub fn new() -> Self {
-        Self {
-            coder_type: CoderTypeDiscriminants::StrUtf8,
-        }
-    }
-}
+#[derive(Clone, Default)]
+pub struct StrUtf8Coder {}
 
 // TODO: accept string references as well?
 impl CoderI for StrUtf8Coder {
@@ -57,10 +47,6 @@ impl CoderI for StrUtf8Coder {
         STR_UTF8_CODER_URN
     }
 
-    fn get_coder_type(&self) -> &CoderTypeDiscriminants {
-        &self.coder_type
-    }
-
     fn encode(
         &self,
         element: String,
@@ -68,12 +54,12 @@ impl CoderI for StrUtf8Coder {
         context: &Context,
     ) -> Result<usize, io::Error> {
         let bytes = element.as_bytes().to_vec();
-        let coder = BytesCoder::new();
+        let coder = BytesCoder::default();
         coder.encode(bytes, writer, context)
     }
 
     fn decode(&self, reader: &mut dyn Read, context: &Context) -> Result<String, io::Error> {
-        let coder = BytesCoder::new();
+        let coder = BytesCoder::default();
         let bytes = coder.decode(reader, context)?;
 
         let res = String::from_utf8(bytes);
@@ -89,12 +75,6 @@ impl CoderI for StrUtf8Coder {
     }
 }
 
-impl Default for StrUtf8Coder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl fmt::Debug for StrUtf8Coder {
     fn fmt<'a>(&'a self, o: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         o.debug_struct("StrUtf8Coder")
@@ -105,17 +85,7 @@ impl fmt::Debug for StrUtf8Coder {
 
 #[derive(Clone)]
 pub struct VarIntCoder<N: fmt::Debug + VarInt> {
-    coder_type: CoderTypeDiscriminants,
     _var_int_type: std::marker::PhantomData<N>,
-}
-
-impl<N: fmt::Debug + VarInt> VarIntCoder<N> {
-    pub fn new() -> Self {
-        Self {
-            coder_type: CoderTypeDiscriminants::VarIntCoder,
-            _var_int_type: std::marker::PhantomData,
-        }
-    }
 }
 
 // TODO: passes tests for -1 if it gets casted to u64 and encoded as such.
@@ -128,10 +98,6 @@ where
 
     fn get_coder_urn() -> &'static str {
         VARINT_CODER_URN
-    }
-
-    fn get_coder_type(&self) -> &CoderTypeDiscriminants {
-        &self.coder_type
     }
 
     // TODO: try to adapt CoderI such that the context arg is not mandatory
@@ -151,7 +117,9 @@ where
 
 impl<N: fmt::Debug + VarInt> Default for VarIntCoder<N> {
     fn default() -> Self {
-        Self::new()
+        Self {
+            _var_int_type: std::marker::PhantomData,
+        }
     }
 }
 

--- a/sdks/rust/src/elem_types/mod.rs
+++ b/sdks/rust/src/elem_types/mod.rs
@@ -1,4 +1,6 @@
-use crate::coders::required_coders::KV;
+use std::fmt;
+
+use crate::coders::required_coders::{Iterable, KV};
 
 /// Element types used in Beam pipelines (including PTransforms, PCollections, Coders, etc.)
 pub trait ElemType: Send + 'static {}
@@ -11,3 +13,5 @@ where
     V: Send + 'static,
 {
 }
+
+impl<E: ElemType + fmt::Debug> ElemType for Iterable<E> {}

--- a/sdks/rust/src/elem_types/mod.rs
+++ b/sdks/rust/src/elem_types/mod.rs
@@ -3,14 +3,14 @@ use std::fmt;
 use crate::coders::required_coders::{Iterable, KV};
 
 /// Element types used in Beam pipelines (including PTransforms, PCollections, Coders, etc.)
-pub trait ElemType: Send + 'static {}
+pub trait ElemType: Clone + Send + 'static {}
 
 impl ElemType for Vec<u8> {}
 
 impl<K, V> ElemType for KV<K, V>
 where
-    K: Send + 'static,
-    V: Send + 'static,
+    K: Clone + Send + 'static,
+    V: Clone + Send + 'static,
 {
 }
 
@@ -28,3 +28,5 @@ impl ElemType for u16 {}
 impl ElemType for u32 {}
 impl ElemType for u64 {}
 impl ElemType for usize {}
+
+impl ElemType for () {}

--- a/sdks/rust/src/elem_types/mod.rs
+++ b/sdks/rust/src/elem_types/mod.rs
@@ -1,0 +1,13 @@
+use crate::coders::required_coders::KV;
+
+/// Element types used in Beam pipelines (including PTransforms, PCollections, Coders, etc.)
+pub trait ElemType: Send + 'static {}
+
+impl ElemType for Vec<u8> {}
+
+impl<K, V> ElemType for KV<K, V>
+where
+    K: Send + 'static,
+    V: Send + 'static,
+{
+}

--- a/sdks/rust/src/elem_types/mod.rs
+++ b/sdks/rust/src/elem_types/mod.rs
@@ -15,3 +15,16 @@ where
 }
 
 impl<E: ElemType + fmt::Debug> ElemType for Iterable<E> {}
+
+impl ElemType for String {}
+
+impl ElemType for i8 {}
+impl ElemType for i16 {}
+impl ElemType for i32 {}
+impl ElemType for i64 {}
+impl ElemType for isize {}
+impl ElemType for u8 {}
+impl ElemType for u16 {}
+impl ElemType for u32 {}
+impl ElemType for u64 {}
+impl ElemType for usize {}

--- a/sdks/rust/src/internals/pipeline.rs
+++ b/sdks/rust/src/internals/pipeline.rs
@@ -19,6 +19,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
+use crate::elem_types::ElemType;
 use crate::proto::beam_api::pipeline as proto_pipeline;
 
 use crate::internals::pvalue::{flatten_pvalue, PTransform, PValue};
@@ -133,8 +134,8 @@ impl<'a> Pipeline {
         input: &PValue<In>,
     ) -> (String, proto_pipeline::PTransform)
     where
-        In: Clone + Send,
-        Out: Clone + Send,
+        In: ElemType,
+        Out: ElemType,
         F: PTransform<In, Out> + Send,
     {
         let transform_id = self.context.create_unique_name("transform".to_string());
@@ -215,11 +216,11 @@ impl<'a> Pipeline {
         pipeline: Arc<Pipeline>,
     ) -> PValue<Out>
     where
-        In: Clone + Send,
-        Out: Clone + Send,
+        In: ElemType,
+        Out: ElemType,
         F: PTransform<In, Out> + Send,
     {
-        let (transform_id, transform_proto) = self.pre_apply_transform(&transform, &input);
+        let (transform_id, transform_proto) = self.pre_apply_transform(&transform, input);
 
         let mut transform_stack = self.transform_stack.lock().unwrap();
 
@@ -243,8 +244,8 @@ impl<'a> Pipeline {
         result: PValue<Out>,
     ) -> PValue<Out>
     where
-        In: Clone + Send,
-        Out: Clone + Send,
+        In: ElemType,
+        Out: ElemType,
         F: PTransform<In, Out> + Send,
     {
         result
@@ -256,7 +257,7 @@ impl<'a> Pipeline {
         pipeline: Arc<Pipeline>,
     ) -> PValue<Out>
     where
-        Out: Clone + Send,
+        Out: ElemType,
     {
         // TODO: remove pcoll_proto arg
         PValue::new(

--- a/sdks/rust/src/internals/pipeline.rs
+++ b/sdks/rust/src/internals/pipeline.rs
@@ -16,11 +16,9 @@
  * limitations under the License.
  */
 
-use std::any::{Any, TypeId};
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
-use crate::coders::coders::CoderI;
 use crate::proto::beam_api::pipeline as proto_pipeline;
 
 use crate::internals::pvalue::{flatten_pvalue, PTransform, PValue};
@@ -65,10 +63,6 @@ pub struct Pipeline {
     transform_stack: Arc<Mutex<Vec<String>>>,
     used_stage_names: Arc<Mutex<HashSet<String>>>,
 
-    // TODO: stop using TypeId as a key
-    // TODO: use something better than Any (maybe use CoderI with an "as_any" method)
-    coders: Mutex<HashMap<TypeId, Box<dyn Any + Send>>>,
-
     coder_proto_counter: Mutex<usize>,
 }
 
@@ -94,36 +88,12 @@ impl<'a> Pipeline {
             transform_stack: Arc::new(Mutex::new(Vec::with_capacity(0))),
             used_stage_names: Arc::new(Mutex::new(HashSet::with_capacity(0))),
 
-            coders: Mutex::new(HashMap::new()),
             coder_proto_counter: Mutex::new(0),
         }
     }
 
     pub fn get_proto(&self) -> Arc<std::sync::Mutex<proto_pipeline::Pipeline>> {
         self.proto.clone()
-    }
-
-    pub fn get_coder<C: CoderI + Clone + 'static>(&self, coder_type: &TypeId) -> C {
-        let pipeline_coders = self.coders.lock().unwrap();
-
-        let coder = pipeline_coders.get(coder_type).unwrap();
-        coder.downcast_ref::<C>().unwrap().clone()
-    }
-
-    pub fn register_coder<C: CoderI + 'a>(&self, coder: Box<dyn Any + Send + 'a>) -> TypeId {
-        let mut coders = self.coders.lock().unwrap();
-        let concrete_coder = coder.downcast_ref::<C>().unwrap();
-        let concrete_coder_type_id = concrete_coder.type_id();
-
-        for registered_type_id in coders.keys() {
-            if *registered_type_id == concrete_coder_type_id {
-                return *registered_type_id;
-            }
-        }
-
-        coders.insert(concrete_coder_type_id, coder);
-
-        concrete_coder_type_id
     }
 
     // TODO: review need for separate function vs register_coder

--- a/sdks/rust/src/internals/pipeline.rs
+++ b/sdks/rust/src/internals/pipeline.rs
@@ -103,14 +103,14 @@ impl<'a> Pipeline {
         self.proto.clone()
     }
 
-    pub fn get_coder<C: CoderI<E> + Clone + 'static, E>(&self, coder_type: &TypeId) -> C {
+    pub fn get_coder<C: CoderI + Clone + 'static>(&self, coder_type: &TypeId) -> C {
         let pipeline_coders = self.coders.lock().unwrap();
 
         let coder = pipeline_coders.get(coder_type).unwrap();
         coder.downcast_ref::<C>().unwrap().clone()
     }
 
-    pub fn register_coder<C: CoderI<E> + 'a, E>(&self, coder: Box<dyn Any + Send + 'a>) -> TypeId {
+    pub fn register_coder<C: CoderI + 'a>(&self, coder: Box<dyn Any + Send + 'a>) -> TypeId {
         let mut coders = self.coders.lock().unwrap();
         let concrete_coder = coder.downcast_ref::<C>().unwrap();
         let concrete_coder_type_id = concrete_coder.type_id();

--- a/sdks/rust/src/internals/pvalue.rs
+++ b/sdks/rust/src/internals/pvalue.rs
@@ -74,7 +74,7 @@ where
             component_coder_ids: Vec::with_capacity(0),
         });
 
-        pipeline.register_coder::<BytesCoder, Vec<u8>>(Box::new(BytesCoder::new()));
+        pipeline.register_coder::<BytesCoder>(Box::new(BytesCoder::new()));
 
         let output_proto = proto_pipeline::PCollection {
             unique_name: pcoll_name.clone(),
@@ -105,11 +105,11 @@ where
         )
     }
 
-    pub fn register_pipeline_coder<'a, C: CoderI<E> + 'a, E>(
+    pub fn register_pipeline_coder<'a, C: CoderI + 'a>(
         &self,
         coder: Box<dyn Any + Send + 'a>,
     ) -> TypeId {
-        self.pipeline.register_coder::<C, E>(coder)
+        self.pipeline.register_coder::<C>(coder)
     }
 
     pub fn register_pipeline_coder_proto(&self, coder_proto: proto_pipeline::Coder) -> String {

--- a/sdks/rust/src/internals/pvalue.rs
+++ b/sdks/rust/src/internals/pvalue.rs
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-use std::any::{Any, TypeId};
+use std::any::TypeId;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -74,8 +74,6 @@ where
             component_coder_ids: Vec::with_capacity(0),
         });
 
-        pipeline.register_coder::<BytesCoder>(Box::<BytesCoder>::default());
-
         let output_proto = proto_pipeline::PCollection {
             unique_name: pcoll_name.clone(),
             coder_id: proto_coder_id,
@@ -103,13 +101,6 @@ where
             pipeline,
             crate::internals::utils::get_bad_id(),
         )
-    }
-
-    pub fn register_pipeline_coder<'a, C: CoderI + 'a>(
-        &self,
-        coder: Box<dyn Any + Send + 'a>,
-    ) -> TypeId {
-        self.pipeline.register_coder::<C>(coder)
     }
 
     pub fn register_pipeline_coder_proto(&self, coder_proto: proto_pipeline::Coder) -> String {

--- a/sdks/rust/src/internals/pvalue.rs
+++ b/sdks/rust/src/internals/pvalue.rs
@@ -74,7 +74,7 @@ where
             component_coder_ids: Vec::with_capacity(0),
         });
 
-        pipeline.register_coder::<BytesCoder>(Box::new(BytesCoder::new()));
+        pipeline.register_coder::<BytesCoder>(Box::<BytesCoder>::default());
 
         let output_proto = proto_pipeline::PCollection {
             unique_name: pcoll_name.clone(),

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -17,6 +17,7 @@
  */
 
 pub mod coders;
+pub mod elem_types;
 pub mod internals;
 pub mod proto;
 pub mod runners;

--- a/sdks/rust/src/runners/runner.rs
+++ b/sdks/rust/src/runners/runner.rs
@@ -21,6 +21,7 @@ use std::{pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
 
+use crate::elem_types::ElemType;
 use crate::internals::pipeline::Pipeline;
 use crate::internals::pvalue::PValue;
 use crate::proto::beam_api::pipeline as proto_pipeline;
@@ -40,8 +41,8 @@ pub trait RunnerI {
     /// Use run_async() to execute the pipeline in the background.
     async fn run<In, Out, F>(&self, pipeline: F)
     where
-        In: Clone + Send,
-        Out: Clone + Send,
+        In: ElemType,
+        Out: ElemType,
         F: FnOnce(PValue<In>) -> PValue<Out> + Send,
     {
         self.run_async(pipeline).await;
@@ -52,8 +53,8 @@ pub trait RunnerI {
     /// status.
     async fn run_async<In, Out, F>(&self, pipeline: F)
     where
-        In: Clone + Send,
-        Out: Clone + Send,
+        In: ElemType,
+        Out: ElemType,
         F: FnOnce(PValue<In>) -> PValue<Out> + Send,
     {
         let p = Arc::new(Pipeline::default());

--- a/sdks/rust/src/tests/coders_test.rs
+++ b/sdks/rust/src/tests/coders_test.rs
@@ -180,7 +180,7 @@ mod tests {
         }
     }
 
-    fn run_unnested<'a, C, E>(coder: &(dyn Any + 'a), _nested: bool, spec: &Value)
+    fn run_unnested<'a, C, E>(coder: &C, _nested: bool, spec: &Value)
     where
         C: CoderI<E> + CoderTestUtils + CoderTestUtils<InternalCoderType = E> + 'a,
         E: Clone + std::fmt::Debug + PartialEq,
@@ -193,12 +193,11 @@ mod tests {
         }
     }
 
-    fn run_case<'a, C, E>(coder: &(dyn Any + 'a), expected_encoded: &Value, original: &Value)
+    fn run_case<'a, C, E>(coder: &C, expected_encoded: &Value, original: &Value)
     where
         C: CoderI<E> + CoderTestUtils + CoderTestUtils<InternalCoderType = E> + 'a,
         E: Clone + std::fmt::Debug + PartialEq,
     {
-        let c: &C = coder.downcast_ref::<C>().unwrap();
         // The expected encodings in standard_coders.yaml need to be read as UTF-16
         let expected_enc_utf16: Vec<u16> =
             expected_encoded.as_str().unwrap().encode_utf16().collect();
@@ -213,15 +212,15 @@ mod tests {
         // TODO: revisit when context gets fully implemented
         let context = Context::WholeStream;
 
-        let expected_dec = c.parse_yaml_value(original);
+        let expected_dec = coder.parse_yaml_value(original);
 
-        c.encode(expected_dec.clone(), &mut writer, &context)
+        coder.encode(expected_dec.clone(), &mut writer, &context)
             .unwrap();
         let encoded = writer.into_inner();
 
-        let decoded = c.decode(&mut reader, &context).unwrap();
+        let decoded = coder.decode(&mut reader, &context).unwrap();
 
-        println!("\n---------\nCoder type: {:?}", c.get_coder_type());
+        println!("\n---------\nCoder type: {:?}", coder.get_coder_type());
         println!(
             "\nExpected encoded: {:?}\nGenerated encoded: {:?}\n\nExpected decoded: {:?}\nGenerated decoded: {:?}",
             expected_enc.as_slice(), encoded, expected_dec, decoded

--- a/sdks/rust/src/tests/coders_test.rs
+++ b/sdks/rust/src/tests/coders_test.rs
@@ -164,15 +164,15 @@ mod tests {
             // TODO: generalize
             match coder_type {
                 CoderTypeDiscriminants::Bytes => {
-                    let c = BytesCoder::new();
+                    let c = BytesCoder::default();
                     run_unnested::<BytesCoder>(&c, nested, &spec);
                 }
                 CoderTypeDiscriminants::StrUtf8 => {
-                    let c = StrUtf8Coder::new();
+                    let c = StrUtf8Coder::default();
                     run_unnested::<StrUtf8Coder>(&c, nested, &spec);
                 }
                 CoderTypeDiscriminants::VarIntCoder => {
-                    let c = VarIntCoder::new();
+                    let c = VarIntCoder::default();
                     run_unnested::<VarIntCoder<u64>>(&c, nested, &spec);
                 }
                 _ => todo!(),
@@ -221,7 +221,7 @@ mod tests {
 
         let decoded = coder.decode(&mut reader, &context).unwrap();
 
-        println!("\n---------\nCoder type: {:?}", coder.get_coder_type());
+        println!("\n---------\nCoder type: {:?}", coder);
         println!(
             "\nExpected encoded: {:?}\nGenerated encoded: {:?}\n\nExpected decoded: {:?}\nGenerated decoded: {:?}",
             expected_enc.as_slice(), encoded, expected_dec, decoded
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn test_general_object_coder() {
         fn string_test() {
-            let coder: GeneralObjectCoder<String> = GeneralObjectCoder::new();
+            let coder: GeneralObjectCoder<String> = GeneralObjectCoder::default();
             let input = "abcde".to_string();
 
             let mut writer = vec![].writer();

--- a/sdks/rust/src/tests/coders_test.rs
+++ b/sdks/rust/src/tests/coders_test.rs
@@ -23,7 +23,8 @@ mod tests {
             coders::{
                 coder_resolver::{
                     BytesCoderResolverDefault, CoderResolver, IterableCoderResolverDefault,
-                    KVCoderResolverDefault,
+                    KVCoderResolverDefault, StrUtf8CoderResolverDefault,
+                    VarIntCoderResolverDefault,
                 },
                 *,
             },
@@ -177,6 +178,10 @@ mod tests {
 
     fn run_unnested(coder_urn: &str, nested: bool, spec: &Value) {
         if let Some(c) = BytesCoderResolverDefault::resolve(coder_urn) {
+            _run_unnested(&c, nested, spec)
+        } else if let Some(c) = StrUtf8CoderResolverDefault::resolve(coder_urn) {
+            _run_unnested(&c, nested, spec)
+        } else if let Some(c) = VarIntCoderResolverDefault::<u64>::resolve(coder_urn) {
             _run_unnested(&c, nested, spec)
         } else {
             todo!()

--- a/sdks/rust/src/tests/coders_test.rs
+++ b/sdks/rust/src/tests/coders_test.rs
@@ -35,7 +35,7 @@ mod tests {
         elem_types::ElemType,
     };
 
-    use std::any::Any;
+
     use std::fmt;
 
     use bytes::{Buf, BufMut};

--- a/sdks/rust/src/tests/primitives_test.rs
+++ b/sdks/rust/src/tests/primitives_test.rs
@@ -18,7 +18,6 @@
 
 #[cfg(test)]
 mod tests {
-    use std::any::Any;
     use std::sync::Arc;
 
     use crate::coders::required_coders::BytesCoder;
@@ -49,10 +48,6 @@ mod tests {
         //     .get(&root_clone.pcoll_proto.coder_id)
         //     .unwrap();
 
-        let bytes_coder_type_id = BytesCoder::default().type_id();
-        let coder = p.get_coder::<BytesCoder>(&bytes_coder_type_id);
-
         assert_eq!(*pcoll.get_type(), PType::PCollection);
-        assert_eq!(coder.type_id(), bytes_coder_type_id);
     }
 }

--- a/sdks/rust/src/tests/primitives_test.rs
+++ b/sdks/rust/src/tests/primitives_test.rs
@@ -49,7 +49,7 @@ mod tests {
         //     .get(&root_clone.pcoll_proto.coder_id)
         //     .unwrap();
 
-        let bytes_coder_type_id = BytesCoder::new().type_id();
+        let bytes_coder_type_id = BytesCoder::default().type_id();
         let coder = p.get_coder::<BytesCoder>(&bytes_coder_type_id);
 
         assert_eq!(*pcoll.get_type(), PType::PCollection);

--- a/sdks/rust/src/tests/primitives_test.rs
+++ b/sdks/rust/src/tests/primitives_test.rs
@@ -50,7 +50,7 @@ mod tests {
         //     .unwrap();
 
         let bytes_coder_type_id = BytesCoder::new().type_id();
-        let coder = p.get_coder::<BytesCoder, Vec<u8>>(&bytes_coder_type_id);
+        let coder = p.get_coder::<BytesCoder>(&bytes_coder_type_id);
 
         assert_eq!(*pcoll.get_type(), PType::PCollection);
         assert_eq!(coder.type_id(), bytes_coder_type_id);

--- a/sdks/rust/src/transforms/impulse.rs
+++ b/sdks/rust/src/transforms/impulse.rs
@@ -36,7 +36,7 @@ impl Impulse {
 
 // Input type should be never(!)
 // https://github.com/rust-lang/rust/issues/35121
-pub type Never = bool;
+pub type Never = ();
 
 impl PTransform<Never, Vec<u8>> for Impulse {
     fn expand_internal(

--- a/sdks/rust/src/worker/operators.rs
+++ b/sdks/rust/src/worker/operators.rs
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
- Removes all `Any`s
- Adds `trait ElemType` for beam-enabled types
  - Used in `PValue`, `PTransform`, and `CoderI`
- Remove `CoderRegistry`
  - Add `CoderResolver` instead, which resolves coders from an `ElemType` (3rd-party coders are also possible in design)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
